### PR TITLE
feat: add Intervals.icu integration with connect/disconnect/status

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ ai-cycling-trainer/
 Clean Architecture with 4 layers:
 
 - `src/domain/` — Pure business logic: entities, repository interfaces, value objects
-- `src/application/` — Orchestration: services and use cases
+- `src/application/` — Orchestration: services and use cases, no httpException
 - `src/infrastructure/` — Technical implementations: database, config, HTTP clients (Intervals.icu)
 - `src/presentation/` — API surface: controllers, DTOs, guards
 - `src/shared/` — Internal shared utilities
@@ -94,12 +94,12 @@ docker compose down    # Stop all services
 
 ### Services
 
-| Service | URL | Description |
-|---------|-----|-------------|
-| Frontend | http://localhost:3001 | React app served by nginx |
-| API | http://localhost:3000/api/v1 | NestJS backend |
-| Swagger | http://localhost:3000/api/docs | API documentation |
-| Prisma Studio | http://localhost:5555 | Database inspection UI |
+| Service       | URL                            | Description               |
+| ------------- | ------------------------------ | ------------------------- |
+| Frontend      | http://localhost:3001          | React app served by nginx |
+| API           | http://localhost:3000/api/v1   | NestJS backend            |
+| Swagger       | http://localhost:3000/api/docs | API documentation         |
+| Prisma Studio | http://localhost:5555          | Database inspection UI    |
 
 ### Environment Variables
 

--- a/apps/api/src/app.module.ts
+++ b/apps/api/src/app.module.ts
@@ -1,7 +1,10 @@
 import { Module } from '@nestjs/common';
 import { ConfigModule } from '@nestjs/config';
+import { APP_FILTER } from '@nestjs/core';
 import { DatabaseModule } from '@infrastructure/database/database.module';
+import { DomainExceptionFilter } from '@presentation/filters/domain-exception.filter';
 import { AuthModule } from './auth.module';
+import { IntervalsIcuModule } from './intervals-icu.module';
 
 @Module({
   imports: [
@@ -11,8 +14,14 @@ import { AuthModule } from './auth.module';
     }),
     DatabaseModule,
     AuthModule,
+    IntervalsIcuModule,
   ],
   controllers: [],
-  providers: [],
+  providers: [
+    {
+      provide: APP_FILTER,
+      useClass: DomainExceptionFilter,
+    },
+  ],
 })
 export class AppModule {}

--- a/apps/api/src/application/services/intervals-icu-client.interface.ts
+++ b/apps/api/src/application/services/intervals-icu-client.interface.ts
@@ -1,0 +1,10 @@
+export const INTERVALS_ICU_CLIENT = Symbol('INTERVALS_ICU_CLIENT');
+
+export interface IntervalsIcuAthlete {
+  id: string;
+  name: string;
+}
+
+export interface IIntervalsIcuClient {
+  getAthlete(athleteId: string, apiKey: string): Promise<IntervalsIcuAthlete>;
+}

--- a/apps/api/src/application/use-cases/connect-intervals-icu.use-case.ts
+++ b/apps/api/src/application/use-cases/connect-intervals-icu.use-case.ts
@@ -1,0 +1,41 @@
+import { Injectable, Inject } from '@nestjs/common';
+import { IUserRepository, USER_REPOSITORY } from '@domain/repositories/user.repository.interface';
+import { UserNotFoundException } from '@domain/exceptions/domain.exception';
+import {
+  IIntervalsIcuClient,
+  INTERVALS_ICU_CLIENT,
+} from '@application/services/intervals-icu-client.interface';
+
+interface ConnectInput {
+  userId: string;
+  athleteId: string;
+  apiKey: string;
+}
+
+interface ConnectOutput {
+  athleteName: string;
+}
+
+@Injectable()
+export class ConnectIntervalsIcuUseCase {
+  constructor(
+    @Inject(USER_REPOSITORY)
+    private readonly userRepository: IUserRepository,
+    @Inject(INTERVALS_ICU_CLIENT)
+    private readonly intervalsIcuClient: IIntervalsIcuClient,
+  ) {}
+
+  async execute(input: ConnectInput): Promise<ConnectOutput> {
+    const user = await this.userRepository.findById(input.userId);
+    if (!user) {
+      throw new UserNotFoundException();
+    }
+
+    const athlete = await this.intervalsIcuClient.getAthlete(input.athleteId, input.apiKey);
+
+    const updateData = user.connectIntervalsIcu(input.athleteId, input.apiKey);
+    await this.userRepository.update(input.userId, updateData);
+
+    return { athleteName: athlete.name };
+  }
+}

--- a/apps/api/src/application/use-cases/disconnect-intervals-icu.use-case.ts
+++ b/apps/api/src/application/use-cases/disconnect-intervals-icu.use-case.ts
@@ -1,0 +1,25 @@
+import { Injectable, Inject } from '@nestjs/common';
+import { IUserRepository, USER_REPOSITORY } from '@domain/repositories/user.repository.interface';
+import { UserNotFoundException } from '@domain/exceptions/domain.exception';
+
+interface DisconnectInput {
+  userId: string;
+}
+
+@Injectable()
+export class DisconnectIntervalsIcuUseCase {
+  constructor(
+    @Inject(USER_REPOSITORY)
+    private readonly userRepository: IUserRepository,
+  ) {}
+
+  async execute(input: DisconnectInput): Promise<void> {
+    const user = await this.userRepository.findById(input.userId);
+    if (!user) {
+      throw new UserNotFoundException();
+    }
+
+    const updateData = user.disconnectFromIntervalsIcu();
+    await this.userRepository.update(input.userId, updateData);
+  }
+}

--- a/apps/api/src/application/use-cases/get-intervals-icu-status.use-case.ts
+++ b/apps/api/src/application/use-cases/get-intervals-icu-status.use-case.ts
@@ -1,0 +1,55 @@
+import { Injectable, Inject } from '@nestjs/common';
+import { IUserRepository, USER_REPOSITORY } from '@domain/repositories/user.repository.interface';
+import { UserNotFoundException } from '@domain/exceptions/domain.exception';
+import {
+  IIntervalsIcuClient,
+  INTERVALS_ICU_CLIENT,
+} from '@application/services/intervals-icu-client.interface';
+
+interface StatusInput {
+  userId: string;
+}
+
+interface StatusOutput {
+  connected: boolean;
+  athleteId?: string;
+  athleteName?: string;
+}
+
+@Injectable()
+export class GetIntervalsIcuStatusUseCase {
+  constructor(
+    @Inject(USER_REPOSITORY)
+    private readonly userRepository: IUserRepository,
+    @Inject(INTERVALS_ICU_CLIENT)
+    private readonly intervalsIcuClient: IIntervalsIcuClient,
+  ) {}
+
+  async execute(input: StatusInput): Promise<StatusOutput> {
+    const user = await this.userRepository.findById(input.userId);
+    if (!user) {
+      throw new UserNotFoundException();
+    }
+
+    if (!user.intervalsIcuUserId || !user.intervalsIcuApiKey) {
+      return { connected: false };
+    }
+
+    try {
+      const athlete = await this.intervalsIcuClient.getAthlete(
+        user.intervalsIcuUserId,
+        user.intervalsIcuApiKey,
+      );
+      return {
+        connected: true,
+        athleteId: user.intervalsIcuUserId,
+        athleteName: athlete.name,
+      };
+    } catch {
+      return {
+        connected: false,
+        athleteId: user.intervalsIcuUserId,
+      };
+    }
+  }
+}

--- a/apps/api/src/application/use-cases/login.use-case.ts
+++ b/apps/api/src/application/use-cases/login.use-case.ts
@@ -1,5 +1,6 @@
-import { Injectable, Inject, UnauthorizedException } from '@nestjs/common';
+import { Injectable, Inject } from '@nestjs/common';
 import { IUserRepository, USER_REPOSITORY } from '@domain/repositories/user.repository.interface';
+import { InvalidCredentialsException } from '@domain/exceptions/domain.exception';
 import { IPasswordHasher, PASSWORD_HASHER } from '@application/services/password-hasher.interface';
 import { ITokenService, TOKEN_SERVICE } from '@application/services/token-service.interface';
 
@@ -27,12 +28,12 @@ export class LoginUseCase {
   async execute(input: LoginInput): Promise<LoginOutput> {
     const user = await this.userRepository.findByEmail(input.email);
     if (!user) {
-      throw new UnauthorizedException('Invalid credentials');
+      throw new InvalidCredentialsException();
     }
 
     const isPasswordValid = await this.passwordHasher.compare(input.password, user.passwordHash);
     if (!isPasswordValid) {
-      throw new UnauthorizedException('Invalid credentials');
+      throw new InvalidCredentialsException();
     }
 
     const accessToken = this.tokenService.generateToken({

--- a/apps/api/src/application/use-cases/register.use-case.ts
+++ b/apps/api/src/application/use-cases/register.use-case.ts
@@ -1,5 +1,6 @@
-import { Injectable, Inject, ConflictException } from '@nestjs/common';
+import { Injectable, Inject } from '@nestjs/common';
 import { IUserRepository, USER_REPOSITORY } from '@domain/repositories/user.repository.interface';
+import { EmailAlreadyExistsException } from '@domain/exceptions/domain.exception';
 import { IPasswordHasher, PASSWORD_HASHER } from '@application/services/password-hasher.interface';
 import { ITokenService, TOKEN_SERVICE } from '@application/services/token-service.interface';
 
@@ -29,7 +30,7 @@ export class RegisterUseCase {
   async execute(input: RegisterInput): Promise<RegisterOutput> {
     const existingUser = await this.userRepository.findByEmail(input.email);
     if (existingUser) {
-      throw new ConflictException('Email already registered');
+      throw new EmailAlreadyExistsException();
     }
 
     const passwordHash = await this.passwordHasher.hash(input.password);

--- a/apps/api/src/auth.module.ts
+++ b/apps/api/src/auth.module.ts
@@ -3,9 +3,6 @@ import { JwtModule } from '@nestjs/jwt';
 import { PassportModule } from '@nestjs/passport';
 import { ConfigService } from '@nestjs/config';
 
-// Domain
-import { USER_REPOSITORY } from '@domain/repositories/user.repository.interface';
-
 // Application
 import { RegisterUseCase } from '@application/use-cases/register.use-case';
 import { LoginUseCase } from '@application/use-cases/login.use-case';
@@ -13,7 +10,7 @@ import { PASSWORD_HASHER } from '@application/services/password-hasher.interface
 import { TOKEN_SERVICE } from '@application/services/token-service.interface';
 
 // Infrastructure
-import { PrismaUserRepository } from '@infrastructure/database/repositories/prisma-user.repository';
+import { RepositoryModule } from '@infrastructure/database/repository.module';
 import { BcryptPasswordHasher } from '@infrastructure/auth/bcrypt-password-hasher';
 import { JwtTokenService } from '@infrastructure/auth/jwt-token.service';
 import { JwtStrategy } from '@infrastructure/auth/jwt.strategy';
@@ -23,6 +20,7 @@ import { AuthController } from '@presentation/controllers/auth.controller';
 
 @Module({
   imports: [
+    RepositoryModule,
     PassportModule.register({ defaultStrategy: 'jwt' }),
     JwtModule.registerAsync({
       inject: [ConfigService],
@@ -41,10 +39,6 @@ import { AuthController } from '@presentation/controllers/auth.controller';
     LoginUseCase,
 
     // Infrastructure -> Domain bindings (Dependency Inversion)
-    {
-      provide: USER_REPOSITORY,
-      useClass: PrismaUserRepository,
-    },
     {
       provide: PASSWORD_HASHER,
       useClass: BcryptPasswordHasher,

--- a/apps/api/src/domain/entities/user.entity.ts
+++ b/apps/api/src/domain/entities/user.entity.ts
@@ -8,4 +8,21 @@ export class UserEntity {
   intervalsIcuApiKey?: string;
   createdAt: Date;
   updatedAt: Date;
+
+  connectIntervalsIcu(
+    athleteId: string,
+    apiKey: string,
+  ): { intervalsIcuUserId: string; intervalsIcuApiKey: string } {
+    return {
+      intervalsIcuUserId: athleteId,
+      intervalsIcuApiKey: apiKey,
+    };
+  }
+
+  disconnectFromIntervalsIcu(): { intervalsIcuUserId: null; intervalsIcuApiKey: null } {
+    return {
+      intervalsIcuUserId: null,
+      intervalsIcuApiKey: null,
+    };
+  }
 }

--- a/apps/api/src/domain/exceptions/domain.exception.ts
+++ b/apps/api/src/domain/exceptions/domain.exception.ts
@@ -1,0 +1,35 @@
+export class DomainException extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+  ) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}
+
+export class UserNotFoundException extends DomainException {
+  constructor(message = 'User not found') {
+    super(message, 'USER_NOT_FOUND');
+  }
+}
+
+export class InvalidCredentialsException extends DomainException {
+  constructor(message = 'Invalid credentials') {
+    super(message, 'INVALID_CREDENTIALS');
+  }
+}
+
+export class EmailAlreadyExistsException extends DomainException {
+  constructor(message = 'Email already registered') {
+    super(message, 'EMAIL_ALREADY_EXISTS');
+  }
+}
+
+export class InvalidIntervalsIcuCredentialsException extends DomainException {
+  constructor(
+    message = 'Invalid Intervals.icu credentials. Please check your athlete ID and API key.',
+  ) {
+    super(message, 'INVALID_INTERVALS_ICU_CREDENTIALS');
+  }
+}

--- a/apps/api/src/domain/exceptions/index.ts
+++ b/apps/api/src/domain/exceptions/index.ts
@@ -1,0 +1,1 @@
+export * from './domain.exception';

--- a/apps/api/src/domain/repositories/user.repository.interface.ts
+++ b/apps/api/src/domain/repositories/user.repository.interface.ts
@@ -2,8 +2,25 @@ import { UserEntity } from '../entities/user.entity';
 
 export const USER_REPOSITORY = Symbol('USER_REPOSITORY');
 
+export interface UpdateUserData {
+  email?: string;
+  firstName?: string;
+  lastName?: string;
+  passwordHash?: string;
+  intervalsIcuUserId?: string | null;
+  intervalsIcuApiKey?: string | null;
+}
+
+export interface CreateUserData {
+  email: string;
+  firstName: string;
+  lastName: string;
+  passwordHash: string;
+}
+
 export interface IUserRepository {
   findById(id: string): Promise<UserEntity | null>;
   findByEmail(email: string): Promise<UserEntity | null>;
-  create(user: Omit<UserEntity, 'id' | 'createdAt' | 'updatedAt'>): Promise<UserEntity>;
+  create(user: CreateUserData): Promise<UserEntity>;
+  update(id: string, data: UpdateUserData): Promise<UserEntity>;
 }

--- a/apps/api/src/infrastructure/database/repositories/prisma-user.repository.ts
+++ b/apps/api/src/infrastructure/database/repositories/prisma-user.repository.ts
@@ -1,21 +1,33 @@
 import { Injectable } from '@nestjs/common';
 import { PrismaService } from '../prisma.service';
-import { IUserRepository } from '@domain/repositories/user.repository.interface';
+import { IUserRepository, CreateUserData, UpdateUserData } from '@domain/repositories/user.repository.interface';
 import { UserEntity } from '@domain/entities/user.entity';
 
 @Injectable()
 export class PrismaUserRepository implements IUserRepository {
   constructor(private readonly prisma: PrismaService) {}
 
+  private toEntity(data: Record<string, unknown>): UserEntity {
+    return Object.assign(new UserEntity(), data);
+  }
+
   async findById(id: string): Promise<UserEntity | null> {
-    return this.prisma.user.findUnique({ where: { id } });
+    const user = await this.prisma.user.findUnique({ where: { id } });
+    return user ? this.toEntity(user) : null;
   }
 
   async findByEmail(email: string): Promise<UserEntity | null> {
-    return this.prisma.user.findUnique({ where: { email } });
+    const user = await this.prisma.user.findUnique({ where: { email } });
+    return user ? this.toEntity(user) : null;
   }
 
-  async create(data: Omit<UserEntity, 'id' | 'createdAt' | 'updatedAt'>): Promise<UserEntity> {
-    return this.prisma.user.create({ data });
+  async create(data: CreateUserData): Promise<UserEntity> {
+    const user = await this.prisma.user.create({ data });
+    return this.toEntity(user);
+  }
+
+  async update(id: string, data: UpdateUserData): Promise<UserEntity> {
+    const user = await this.prisma.user.update({ where: { id }, data });
+    return this.toEntity(user);
   }
 }

--- a/apps/api/src/infrastructure/database/repository.module.ts
+++ b/apps/api/src/infrastructure/database/repository.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+import { USER_REPOSITORY } from '@domain/repositories/user.repository.interface';
+import { PrismaUserRepository } from './repositories/prisma-user.repository';
+
+@Module({
+  providers: [
+    {
+      provide: USER_REPOSITORY,
+      useClass: PrismaUserRepository,
+    },
+  ],
+  exports: [USER_REPOSITORY],
+})
+export class RepositoryModule {}

--- a/apps/api/src/infrastructure/http/intervals-icu/intervals-icu.client.ts
+++ b/apps/api/src/infrastructure/http/intervals-icu/intervals-icu.client.ts
@@ -1,0 +1,36 @@
+import { Injectable } from '@nestjs/common';
+import { InvalidIntervalsIcuCredentialsException } from '@domain/exceptions/domain.exception';
+import {
+  IIntervalsIcuClient,
+  IntervalsIcuAthlete,
+} from '@application/services/intervals-icu-client.interface';
+
+@Injectable()
+export class IntervalsIcuClient implements IIntervalsIcuClient {
+  private readonly baseUrl = 'https://intervals.icu/api/v1';
+
+  async getAthlete(athleteId: string, apiKey: string): Promise<IntervalsIcuAthlete> {
+    const credentials = Buffer.from(`API_KEY:${apiKey}`).toString('base64');
+
+    const response = await fetch(`${this.baseUrl}/athlete/${athleteId}`, {
+      method: 'GET',
+      headers: {
+        Authorization: `Basic ${credentials}`,
+      },
+    });
+
+    if (!response.ok) {
+      if (response.status === 401 || response.status === 403) {
+        throw new InvalidIntervalsIcuCredentialsException();
+      }
+      throw new Error(`Intervals.icu API error: ${response.status} ${response.statusText}`);
+    }
+
+    const data: Record<string, any> = await response.json();
+
+    return {
+      id: data.id,
+      name: data.name ?? `${data.firstname ?? ''} ${data.lastname ?? ''}`.trim(),
+    };
+  }
+}

--- a/apps/api/src/intervals-icu.module.ts
+++ b/apps/api/src/intervals-icu.module.ts
@@ -1,0 +1,32 @@
+import { Module } from '@nestjs/common';
+
+// Application
+import { INTERVALS_ICU_CLIENT } from '@application/services/intervals-icu-client.interface';
+import { ConnectIntervalsIcuUseCase } from '@application/use-cases/connect-intervals-icu.use-case';
+import { DisconnectIntervalsIcuUseCase } from '@application/use-cases/disconnect-intervals-icu.use-case';
+import { GetIntervalsIcuStatusUseCase } from '@application/use-cases/get-intervals-icu-status.use-case';
+
+// Infrastructure
+import { RepositoryModule } from '@infrastructure/database/repository.module';
+import { IntervalsIcuClient } from '@infrastructure/http/intervals-icu/intervals-icu.client';
+
+// Presentation
+import { UserController } from '@presentation/controllers/user.controller';
+
+@Module({
+  imports: [RepositoryModule],
+  controllers: [UserController],
+  providers: [
+    // Use cases
+    ConnectIntervalsIcuUseCase,
+    DisconnectIntervalsIcuUseCase,
+    GetIntervalsIcuStatusUseCase,
+
+    // Infrastructure -> Domain bindings
+    {
+      provide: INTERVALS_ICU_CLIENT,
+      useClass: IntervalsIcuClient,
+    },
+  ],
+})
+export class IntervalsIcuModule {}

--- a/apps/api/src/presentation/controllers/user.controller.ts
+++ b/apps/api/src/presentation/controllers/user.controller.ts
@@ -1,0 +1,64 @@
+import {
+  Controller,
+  Put,
+  Delete,
+  Get,
+  Body,
+  UseGuards,
+  Request,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
+import { AuthGuard } from '@nestjs/passport';
+import { ConnectIntervalsIcuUseCase } from '@application/use-cases/connect-intervals-icu.use-case';
+import { DisconnectIntervalsIcuUseCase } from '@application/use-cases/disconnect-intervals-icu.use-case';
+import { GetIntervalsIcuStatusUseCase } from '@application/use-cases/get-intervals-icu-status.use-case';
+import {
+  ConnectIntervalsIcuRequestDto,
+  ConnectIntervalsIcuResponseDto,
+  IntervalsIcuStatusResponseDto,
+} from '../dtos/intervals-icu.dto';
+
+@ApiTags('intervals-icu')
+@Controller('users/me')
+@UseGuards(AuthGuard('jwt'))
+@ApiBearerAuth()
+export class UserController {
+  constructor(
+    private readonly connectUseCase: ConnectIntervalsIcuUseCase,
+    private readonly disconnectUseCase: DisconnectIntervalsIcuUseCase,
+    private readonly getStatusUseCase: GetIntervalsIcuStatusUseCase,
+  ) {}
+
+  @Put('intervals-icu')
+  @ApiOperation({ summary: 'Connect Intervals.icu account' })
+  @ApiResponse({ status: 200, type: ConnectIntervalsIcuResponseDto })
+  @ApiResponse({ status: 422, description: 'Invalid Intervals.icu credentials' })
+  @HttpCode(HttpStatus.OK)
+  async connectIntervalsIcu(
+    @Request() req,
+    @Body() dto: ConnectIntervalsIcuRequestDto,
+  ): Promise<ConnectIntervalsIcuResponseDto> {
+    return this.connectUseCase.execute({
+      userId: req.user.id,
+      athleteId: dto.athleteId,
+      apiKey: dto.apiKey,
+    });
+  }
+
+  @Delete('intervals-icu')
+  @ApiOperation({ summary: 'Disconnect Intervals.icu account' })
+  @ApiResponse({ status: 204, description: 'Successfully disconnected' })
+  @HttpCode(HttpStatus.NO_CONTENT)
+  async disconnectIntervalsIcu(@Request() req): Promise<void> {
+    await this.disconnectUseCase.execute({ userId: req.user.id });
+  }
+
+  @Get('intervals-icu/status')
+  @ApiOperation({ summary: 'Get Intervals.icu connection status' })
+  @ApiResponse({ status: 200, type: IntervalsIcuStatusResponseDto })
+  async getIntervalsIcuStatus(@Request() req): Promise<IntervalsIcuStatusResponseDto> {
+    return this.getStatusUseCase.execute({ userId: req.user.id });
+  }
+}

--- a/apps/api/src/presentation/dtos/intervals-icu.dto.ts
+++ b/apps/api/src/presentation/dtos/intervals-icu.dto.ts
@@ -1,0 +1,30 @@
+import { IsString, IsNotEmpty } from 'class-validator';
+import { ApiProperty } from '@nestjs/swagger';
+
+export class ConnectIntervalsIcuRequestDto {
+  @ApiProperty({ example: 'i12345', description: 'Your Intervals.icu athlete ID' })
+  @IsString()
+  @IsNotEmpty()
+  athleteId: string;
+
+  @ApiProperty({ example: 'abc123...', description: 'Your Intervals.icu API key' })
+  @IsString()
+  @IsNotEmpty()
+  apiKey: string;
+}
+
+export class ConnectIntervalsIcuResponseDto {
+  @ApiProperty({ example: 'John Doe' })
+  athleteName: string;
+}
+
+export class IntervalsIcuStatusResponseDto {
+  @ApiProperty({ example: true })
+  connected: boolean;
+
+  @ApiProperty({ example: 'i12345', required: false })
+  athleteId?: string;
+
+  @ApiProperty({ example: 'John Doe', required: false })
+  athleteName?: string;
+}

--- a/apps/api/src/presentation/filters/domain-exception.filter.ts
+++ b/apps/api/src/presentation/filters/domain-exception.filter.ts
@@ -1,0 +1,40 @@
+import { ExceptionFilter, Catch, ArgumentsHost, HttpStatus } from '@nestjs/common';
+import { Response } from 'express';
+import {
+  DomainException,
+  UserNotFoundException,
+  InvalidCredentialsException,
+  EmailAlreadyExistsException,
+  InvalidIntervalsIcuCredentialsException,
+} from '@domain/exceptions/domain.exception';
+
+@Catch(DomainException)
+export class DomainExceptionFilter implements ExceptionFilter {
+  private readonly exceptionToHttpStatus = new Map<
+    Function,
+    { status: HttpStatus; error: string }
+  >([
+    [UserNotFoundException, { status: HttpStatus.NOT_FOUND, error: 'Not Found' }],
+    [InvalidCredentialsException, { status: HttpStatus.UNAUTHORIZED, error: 'Unauthorized' }],
+    [EmailAlreadyExistsException, { status: HttpStatus.CONFLICT, error: 'Conflict' }],
+    [
+      InvalidIntervalsIcuCredentialsException,
+      { status: HttpStatus.UNPROCESSABLE_ENTITY, error: 'Unprocessable Entity' },
+    ],
+  ]);
+
+  catch(exception: DomainException, host: ArgumentsHost) {
+    const ctx = host.switchToHttp();
+    const response = ctx.getResponse<Response>();
+
+    const mapping = this.exceptionToHttpStatus.get(exception.constructor);
+    const status = mapping?.status ?? HttpStatus.INTERNAL_SERVER_ERROR;
+    const error = mapping?.error ?? 'Internal Server Error';
+
+    response.status(status).json({
+      statusCode: status,
+      message: exception.message,
+      error,
+    });
+  }
+}

--- a/apps/api/test/e2e/helpers/intervals-icu-mock.helper.ts
+++ b/apps/api/test/e2e/helpers/intervals-icu-mock.helper.ts
@@ -1,0 +1,31 @@
+import { InvalidIntervalsIcuCredentialsException } from '@domain/exceptions/domain.exception';
+import {
+  IIntervalsIcuClient,
+  IntervalsIcuAthlete,
+} from '../../../src/application/services/intervals-icu-client.interface';
+
+export class MockIntervalsIcuClient implements IIntervalsIcuClient {
+  private shouldSucceed = true;
+  private mockAthlete: IntervalsIcuAthlete = {
+    id: 'i12345',
+    name: 'Test Athlete',
+  };
+
+  setSuccess(athlete?: Partial<IntervalsIcuAthlete>): void {
+    this.shouldSucceed = true;
+    if (athlete) {
+      this.mockAthlete = { ...this.mockAthlete, ...athlete };
+    }
+  }
+
+  setFailure(): void {
+    this.shouldSucceed = false;
+  }
+
+  async getAthlete(athleteId: string): Promise<IntervalsIcuAthlete> {
+    if (!this.shouldSucceed) {
+      throw new InvalidIntervalsIcuCredentialsException();
+    }
+    return { ...this.mockAthlete, id: athleteId };
+  }
+}

--- a/apps/api/test/e2e/helpers/test-app.helper.ts
+++ b/apps/api/test/e2e/helpers/test-app.helper.ts
@@ -14,7 +14,9 @@ const TEST_DATABASE_URL = `file:${TEST_DB_PATH}`;
 let app: INestApplication;
 let prismaService: PrismaService;
 
-export async function createTestApp(): Promise<INestApplication> {
+export async function createTestApp(
+  overrides?: { token: any; value: any }[],
+): Promise<INestApplication> {
   // Set test environment variables before module creation
   process.env.DATABASE_URL = TEST_DATABASE_URL;
   process.env.JWT_SECRET = 'test-jwt-secret-for-e2e';
@@ -27,9 +29,17 @@ export async function createTestApp(): Promise<INestApplication> {
     stdio: 'pipe',
   });
 
-  const moduleFixture: TestingModule = await Test.createTestingModule({
+  let builder = Test.createTestingModule({
     imports: [AppModule],
-  }).compile();
+  });
+
+  if (overrides) {
+    for (const override of overrides) {
+      builder = builder.overrideProvider(override.token).useValue(override.value) as any;
+    }
+  }
+
+  const moduleFixture: TestingModule = await builder.compile();
 
   app = moduleFixture.createNestApplication();
 

--- a/apps/api/test/e2e/intervals-icu/connect.e2e-spec.ts
+++ b/apps/api/test/e2e/intervals-icu/connect.e2e-spec.ts
@@ -1,0 +1,153 @@
+import request from 'supertest';
+import { INestApplication } from '@nestjs/common';
+import { createTestApp, closeTestApp, cleanDatabase } from '../helpers/test-app.helper';
+import { getAuthToken } from '../helpers/auth.helper';
+import { MockIntervalsIcuClient } from '../helpers/intervals-icu-mock.helper';
+import { INTERVALS_ICU_CLIENT } from '../../../src/application/services/intervals-icu-client.interface';
+
+describe('PUT /api/v1/users/me/intervals-icu', () => {
+  let app: INestApplication;
+  let mockClient: MockIntervalsIcuClient;
+
+  beforeAll(async () => {
+    mockClient = new MockIntervalsIcuClient();
+    app = await createTestApp([{ token: INTERVALS_ICU_CLIENT, value: mockClient }]);
+  });
+
+  afterAll(async () => {
+    await closeTestApp();
+  });
+
+  afterEach(async () => {
+    await cleanDatabase();
+    mockClient.setSuccess({ name: 'Test Athlete' });
+  });
+
+  it('should connect and return 200 with athlete name', async () => {
+    const token = await getAuthToken(app);
+    mockClient.setSuccess({ name: 'Lance Strong' });
+
+    const response = await request(app.getHttpServer())
+      .put('/api/v1/users/me/intervals-icu')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ athleteId: 'i12345', apiKey: 'valid-api-key' })
+      .expect(200);
+
+    expect(response.body).toEqual({ athleteName: 'Lance Strong' });
+  });
+
+  it('should persist credentials and be reflected in status', async () => {
+    const token = await getAuthToken(app);
+    mockClient.setSuccess({ name: 'Lance Strong' });
+
+    await request(app.getHttpServer())
+      .put('/api/v1/users/me/intervals-icu')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ athleteId: 'i12345', apiKey: 'valid-api-key' })
+      .expect(200);
+
+    const statusResponse = await request(app.getHttpServer())
+      .get('/api/v1/users/me/intervals-icu/status')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    expect(statusResponse.body.connected).toBe(true);
+    expect(statusResponse.body.athleteId).toBe('i12345');
+  });
+
+  it('should allow updating credentials with a new athlete ID', async () => {
+    const token = await getAuthToken(app);
+    mockClient.setSuccess({ name: 'Athlete One' });
+
+    await request(app.getHttpServer())
+      .put('/api/v1/users/me/intervals-icu')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ athleteId: 'i11111', apiKey: 'key-1' })
+      .expect(200);
+
+    mockClient.setSuccess({ name: 'Athlete Two' });
+
+    await request(app.getHttpServer())
+      .put('/api/v1/users/me/intervals-icu')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ athleteId: 'i22222', apiKey: 'key-2' })
+      .expect(200);
+
+    const statusResponse = await request(app.getHttpServer())
+      .get('/api/v1/users/me/intervals-icu/status')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    expect(statusResponse.body.athleteId).toBe('i22222');
+  });
+
+  it('should return 400 when athleteId is missing', async () => {
+    const token = await getAuthToken(app);
+
+    await request(app.getHttpServer())
+      .put('/api/v1/users/me/intervals-icu')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ apiKey: 'some-key' })
+      .expect(400);
+  });
+
+  it('should return 400 when apiKey is missing', async () => {
+    const token = await getAuthToken(app);
+
+    await request(app.getHttpServer())
+      .put('/api/v1/users/me/intervals-icu')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ athleteId: 'i12345' })
+      .expect(400);
+  });
+
+  it('should return 400 when body is empty', async () => {
+    const token = await getAuthToken(app);
+
+    await request(app.getHttpServer())
+      .put('/api/v1/users/me/intervals-icu')
+      .set('Authorization', `Bearer ${token}`)
+      .send({})
+      .expect(400);
+  });
+
+  it('should return 401 when no token is provided', async () => {
+    await request(app.getHttpServer())
+      .put('/api/v1/users/me/intervals-icu')
+      .send({ athleteId: 'i12345', apiKey: 'some-key' })
+      .expect(401);
+  });
+
+  it('should return 422 when Intervals.icu credentials are invalid', async () => {
+    const token = await getAuthToken(app);
+    mockClient.setFailure();
+
+    const response = await request(app.getHttpServer())
+      .put('/api/v1/users/me/intervals-icu')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ athleteId: 'i12345', apiKey: 'bad-key' })
+      .expect(422);
+
+    expect(response.body.message).toContain('Invalid Intervals.icu credentials');
+  });
+
+  it('should not save credentials when validation against Intervals.icu fails', async () => {
+    const token = await getAuthToken(app);
+    mockClient.setFailure();
+
+    await request(app.getHttpServer())
+      .put('/api/v1/users/me/intervals-icu')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ athleteId: 'i12345', apiKey: 'bad-key' })
+      .expect(422);
+
+    mockClient.setSuccess();
+
+    const statusResponse = await request(app.getHttpServer())
+      .get('/api/v1/users/me/intervals-icu/status')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    expect(statusResponse.body.connected).toBe(false);
+  });
+});

--- a/apps/api/test/e2e/intervals-icu/disconnect.e2e-spec.ts
+++ b/apps/api/test/e2e/intervals-icu/disconnect.e2e-spec.ts
@@ -1,0 +1,66 @@
+import request from 'supertest';
+import { INestApplication } from '@nestjs/common';
+import { createTestApp, closeTestApp, cleanDatabase } from '../helpers/test-app.helper';
+import { getAuthToken } from '../helpers/auth.helper';
+import { MockIntervalsIcuClient } from '../helpers/intervals-icu-mock.helper';
+import { INTERVALS_ICU_CLIENT } from '../../../src/application/services/intervals-icu-client.interface';
+
+describe('DELETE /api/v1/users/me/intervals-icu', () => {
+  let app: INestApplication;
+  let mockClient: MockIntervalsIcuClient;
+
+  beforeAll(async () => {
+    mockClient = new MockIntervalsIcuClient();
+    app = await createTestApp([{ token: INTERVALS_ICU_CLIENT, value: mockClient }]);
+  });
+
+  afterAll(async () => {
+    await closeTestApp();
+  });
+
+  afterEach(async () => {
+    await cleanDatabase();
+    mockClient.setSuccess({ name: 'Test Athlete' });
+  });
+
+  it('should disconnect and return 204', async () => {
+    const token = await getAuthToken(app);
+
+    // First connect
+    await request(app.getHttpServer())
+      .put('/api/v1/users/me/intervals-icu')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ athleteId: 'i12345', apiKey: 'valid-key' })
+      .expect(200);
+
+    // Then disconnect
+    await request(app.getHttpServer())
+      .delete('/api/v1/users/me/intervals-icu')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(204);
+
+    // Verify disconnected
+    const statusResponse = await request(app.getHttpServer())
+      .get('/api/v1/users/me/intervals-icu/status')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    expect(statusResponse.body.connected).toBe(false);
+    expect(statusResponse.body.athleteId).toBeUndefined();
+  });
+
+  it('should return 204 even when not connected (idempotent)', async () => {
+    const token = await getAuthToken(app);
+
+    await request(app.getHttpServer())
+      .delete('/api/v1/users/me/intervals-icu')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(204);
+  });
+
+  it('should return 401 when no token is provided', async () => {
+    await request(app.getHttpServer())
+      .delete('/api/v1/users/me/intervals-icu')
+      .expect(401);
+  });
+});

--- a/apps/api/test/e2e/intervals-icu/status.e2e-spec.ts
+++ b/apps/api/test/e2e/intervals-icu/status.e2e-spec.ts
@@ -1,0 +1,83 @@
+import request from 'supertest';
+import { INestApplication } from '@nestjs/common';
+import { createTestApp, closeTestApp, cleanDatabase } from '../helpers/test-app.helper';
+import { getAuthToken } from '../helpers/auth.helper';
+import { MockIntervalsIcuClient } from '../helpers/intervals-icu-mock.helper';
+import { INTERVALS_ICU_CLIENT } from '../../../src/application/services/intervals-icu-client.interface';
+
+describe('GET /api/v1/users/me/intervals-icu/status', () => {
+  let app: INestApplication;
+  let mockClient: MockIntervalsIcuClient;
+
+  beforeAll(async () => {
+    mockClient = new MockIntervalsIcuClient();
+    app = await createTestApp([{ token: INTERVALS_ICU_CLIENT, value: mockClient }]);
+  });
+
+  afterAll(async () => {
+    await closeTestApp();
+  });
+
+  afterEach(async () => {
+    await cleanDatabase();
+    mockClient.setSuccess({ name: 'Test Athlete' });
+  });
+
+  it('should return disconnected status when user has no credentials', async () => {
+    const token = await getAuthToken(app);
+
+    const response = await request(app.getHttpServer())
+      .get('/api/v1/users/me/intervals-icu/status')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    expect(response.body).toEqual({ connected: false });
+  });
+
+  it('should return connected status with athlete info when connected', async () => {
+    const token = await getAuthToken(app);
+    mockClient.setSuccess({ name: 'Pro Cyclist' });
+
+    await request(app.getHttpServer())
+      .put('/api/v1/users/me/intervals-icu')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ athleteId: 'i99999', apiKey: 'valid-key' })
+      .expect(200);
+
+    const response = await request(app.getHttpServer())
+      .get('/api/v1/users/me/intervals-icu/status')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    expect(response.body.connected).toBe(true);
+    expect(response.body.athleteId).toBe('i99999');
+    expect(response.body.athleteName).toBe('Pro Cyclist');
+  });
+
+  it('should return disconnected when stored credentials are no longer valid', async () => {
+    const token = await getAuthToken(app);
+    mockClient.setSuccess({ name: 'Athlete' });
+
+    await request(app.getHttpServer())
+      .put('/api/v1/users/me/intervals-icu')
+      .set('Authorization', `Bearer ${token}`)
+      .send({ athleteId: 'i12345', apiKey: 'key-that-will-expire' })
+      .expect(200);
+
+    mockClient.setFailure();
+
+    const response = await request(app.getHttpServer())
+      .get('/api/v1/users/me/intervals-icu/status')
+      .set('Authorization', `Bearer ${token}`)
+      .expect(200);
+
+    expect(response.body.connected).toBe(false);
+    expect(response.body.athleteId).toBe('i12345');
+  });
+
+  it('should return 401 when no token is provided', async () => {
+    await request(app.getHttpServer())
+      .get('/api/v1/users/me/intervals-icu/status')
+      .expect(401);
+  });
+});

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -4,6 +4,7 @@ import { ProtectedRoute } from '@/components/ProtectedRoute';
 import { LoginPage } from '@/pages/LoginPage';
 import { RegisterPage } from '@/pages/RegisterPage';
 import { DashboardPage } from '@/pages/DashboardPage';
+import { SettingsPage } from '@/pages/SettingsPage';
 
 function App() {
   return (
@@ -17,6 +18,14 @@ function App() {
             element={
               <ProtectedRoute>
                 <DashboardPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/settings"
+            element={
+              <ProtectedRoute>
+                <SettingsPage />
               </ProtectedRoute>
             }
           />

--- a/apps/web/src/components/AppLayout.tsx
+++ b/apps/web/src/components/AppLayout.tsx
@@ -1,0 +1,55 @@
+import { Link, useLocation } from 'react-router-dom';
+import { useAuth } from '@/app/auth-context';
+
+interface AppLayoutProps {
+  children: React.ReactNode;
+}
+
+const navLinks = [
+  { to: '/dashboard', label: 'Dashboard' },
+  { to: '/settings', label: 'Settings' },
+];
+
+export function AppLayout({ children }: AppLayoutProps) {
+  const { user, logout } = useAuth();
+  const location = useLocation();
+
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <nav className="bg-white shadow">
+        <div className="max-w-7xl mx-auto px-4 py-4 flex justify-between items-center">
+          <div className="flex items-center gap-8">
+            <h1 className="text-xl font-bold text-gray-900">AI Cycling Trainer</h1>
+            <div className="flex gap-4">
+              {navLinks.map((link) => (
+                <Link
+                  key={link.to}
+                  to={link.to}
+                  className={`text-sm font-medium ${
+                    location.pathname === link.to
+                      ? 'text-blue-600'
+                      : 'text-gray-600 hover:text-gray-900'
+                  }`}
+                >
+                  {link.label}
+                </Link>
+              ))}
+            </div>
+          </div>
+          <div className="flex items-center gap-4">
+            <span className="text-sm text-gray-600">
+              {user?.firstName.capitalize()} {user?.lastName.capitalize()}
+            </span>
+            <button
+              onClick={logout}
+              className="text-sm text-red-600 hover:text-red-500 font-medium"
+            >
+              Log out
+            </button>
+          </div>
+        </div>
+      </nav>
+      <main className="max-w-7xl mx-auto px-4 py-8">{children}</main>
+    </div>
+  );
+}

--- a/apps/web/src/pages/DashboardPage.tsx
+++ b/apps/web/src/pages/DashboardPage.tsx
@@ -1,45 +1,27 @@
-import { useAuth } from '@/app/auth-context';
+import { AppLayout } from '@/components/AppLayout';
 
 export function DashboardPage() {
-  const { user, logout } = useAuth();
-
   return (
-    <div className="min-h-screen bg-gray-50">
-      <nav className="bg-white shadow">
-        <div className="max-w-7xl mx-auto px-4 py-4 flex justify-between items-center">
-          <h1 className="text-xl font-bold text-gray-900">AI Cycling Trainer</h1>
-          <div className="flex items-center gap-4">
-            <span className="text-sm text-gray-600">{user?.firstName.capitalize()} {user?.lastName.capitalize()}</span>
-            <button
-              onClick={logout}
-              className="text-sm text-red-600 hover:text-red-500 font-medium"
-            >
-              Log out
-            </button>
-          </div>
+    <AppLayout>
+      <h2 className="text-2xl font-semibold text-gray-900">Dashboard</h2>
+      <p className="mt-2 text-gray-600">Your training dashboard will appear here.</p>
+
+      <div className="mt-8 grid grid-cols-1 md:grid-cols-3 gap-6">
+        <div className="bg-white rounded-lg shadow p-6">
+          <h3 className="text-lg font-medium text-gray-900">Next workout</h3>
+          <p className="mt-2 text-gray-500">No workout scheduled</p>
         </div>
-      </nav>
-      <main className="max-w-7xl mx-auto px-4 py-8">
-        <h2 className="text-2xl font-semibold text-gray-900">Dashboard</h2>
-        <p className="mt-2 text-gray-600">Your training dashboard will appear here.</p>
 
-        <div className="mt-8 grid grid-cols-1 md:grid-cols-3 gap-6">
-          <div className="bg-white rounded-lg shadow p-6">
-            <h3 className="text-lg font-medium text-gray-900">Next workout</h3>
-            <p className="mt-2 text-gray-500">No workout scheduled</p>
-          </div>
-
-          <div className="bg-white rounded-lg shadow p-6">
-            <h3 className="text-lg font-medium text-gray-900">Training load</h3>
-            <p className="mt-2 text-gray-500">No data yet</p>
-          </div>
-
-          <div className="bg-white rounded-lg shadow p-6">
-            <h3 className="text-lg font-medium text-gray-900">Active plan</h3>
-            <p className="mt-2 text-gray-500">No active plan</p>
-          </div>
+        <div className="bg-white rounded-lg shadow p-6">
+          <h3 className="text-lg font-medium text-gray-900">Training load</h3>
+          <p className="mt-2 text-gray-500">No data yet</p>
         </div>
-      </main>
-    </div>
+
+        <div className="bg-white rounded-lg shadow p-6">
+          <h3 className="text-lg font-medium text-gray-900">Active plan</h3>
+          <p className="mt-2 text-gray-500">No active plan</p>
+        </div>
+      </div>
+    </AppLayout>
   );
 }

--- a/apps/web/src/pages/SettingsPage.tsx
+++ b/apps/web/src/pages/SettingsPage.tsx
@@ -1,0 +1,229 @@
+import { useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { AppLayout } from '@/components/AppLayout';
+import {
+  intervalsIcuService,
+  type IntervalsIcuStatus,
+} from '@/services/intervals-icu.service';
+
+interface ConnectFormData {
+  athleteId: string;
+  apiKey: string;
+}
+
+export function SettingsPage() {
+  const queryClient = useQueryClient();
+  const [successMessage, setSuccessMessage] = useState<string | null>(null);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const {
+    data: status,
+    isLoading,
+    isError,
+  } = useQuery<IntervalsIcuStatus>({
+    queryKey: ['intervals-icu-status'],
+    queryFn: intervalsIcuService.getConnectionStatus,
+  });
+
+  const {
+    register,
+    handleSubmit,
+    reset,
+    formState: { errors },
+  } = useForm<ConnectFormData>();
+
+  const connectMutation = useMutation({
+    mutationFn: (data: ConnectFormData) => intervalsIcuService.connect(data),
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['intervals-icu-status'] });
+      setSuccessMessage(`Successfully connected to Intervals.icu as ${data.athleteName}!`);
+      setErrorMessage(null);
+      reset();
+    },
+    onError: (err: any) => {
+      setErrorMessage(
+        err.response?.data?.message ||
+          'Failed to connect. Please check your credentials.',
+      );
+      setSuccessMessage(null);
+    },
+  });
+
+  const disconnectMutation = useMutation({
+    mutationFn: intervalsIcuService.disconnect,
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['intervals-icu-status'] });
+      setSuccessMessage('Disconnected from Intervals.icu.');
+      setErrorMessage(null);
+    },
+    onError: (err: any) => {
+      setErrorMessage(err.response?.data?.message || 'Failed to disconnect.');
+      setSuccessMessage(null);
+    },
+  });
+
+  const onConnect = (data: ConnectFormData) => {
+    setSuccessMessage(null);
+    setErrorMessage(null);
+    connectMutation.mutate(data);
+  };
+
+  const onDisconnect = () => {
+    setSuccessMessage(null);
+    setErrorMessage(null);
+    disconnectMutation.mutate();
+  };
+
+  return (
+    <AppLayout>
+      <h2 className="text-2xl font-semibold text-gray-900">Settings</h2>
+      <p className="mt-2 text-gray-600">Manage your account and integrations.</p>
+
+      <div className="mt-8 max-w-2xl">
+        <div className="bg-white rounded-lg shadow p-6">
+          <div className="flex items-center justify-between">
+            <div>
+              <h3 className="text-lg font-medium text-gray-900">Intervals.icu</h3>
+              <p className="mt-1 text-sm text-gray-500">
+                Connect your Intervals.icu account to sync workouts and training data.
+              </p>
+            </div>
+            {status?.connected && (
+              <span className="inline-flex items-center rounded-full bg-green-100 px-3 py-0.5 text-sm font-medium text-green-800">
+                Connected
+              </span>
+            )}
+          </div>
+
+          {successMessage && (
+            <div className="mt-4 bg-green-50 border border-green-200 text-green-700 px-4 py-3 rounded">
+              {successMessage}
+            </div>
+          )}
+          {errorMessage && (
+            <div className="mt-4 bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded">
+              {errorMessage}
+            </div>
+          )}
+
+          {isLoading && (
+            <p className="mt-4 text-sm text-gray-500">Loading connection status...</p>
+          )}
+
+          {isError && (
+            <div className="mt-4 bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded">
+              Failed to load connection status.
+            </div>
+          )}
+
+          {status?.connected && (
+            <div className="mt-6 space-y-4">
+              <div className="rounded-md bg-gray-50 p-4">
+                <dl className="space-y-2">
+                  <div className="flex justify-between">
+                    <dt className="text-sm font-medium text-gray-500">Athlete ID</dt>
+                    <dd className="text-sm text-gray-900">{status.athleteId}</dd>
+                  </div>
+                  {status.athleteName && (
+                    <div className="flex justify-between">
+                      <dt className="text-sm font-medium text-gray-500">Athlete Name</dt>
+                      <dd className="text-sm text-gray-900">{status.athleteName}</dd>
+                    </div>
+                  )}
+                </dl>
+              </div>
+              <button
+                type="button"
+                onClick={onDisconnect}
+                disabled={disconnectMutation.isPending}
+                className="inline-flex justify-center py-2 px-4 border border-red-300 rounded-md shadow-sm text-sm font-medium text-red-700 bg-white hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {disconnectMutation.isPending ? 'Disconnecting...' : 'Disconnect'}
+              </button>
+            </div>
+          )}
+
+          {status && !status.connected && (
+            <form onSubmit={handleSubmit(onConnect)} className="mt-6 space-y-4">
+              <div>
+                <label
+                  htmlFor="athleteId"
+                  className="block text-sm font-medium text-gray-700"
+                >
+                  Athlete ID
+                </label>
+                <input
+                  id="athleteId"
+                  type="text"
+                  placeholder="i12345"
+                  {...register('athleteId', {
+                    required: 'Athlete ID is required',
+                  })}
+                  className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                />
+                {errors.athleteId && (
+                  <p className="mt-1 text-sm text-red-600">{errors.athleteId.message}</p>
+                )}
+              </div>
+
+              <div>
+                <label
+                  htmlFor="apiKey"
+                  className="block text-sm font-medium text-gray-700"
+                >
+                  API Key
+                </label>
+                <input
+                  id="apiKey"
+                  type="password"
+                  placeholder="Your Intervals.icu API key"
+                  {...register('apiKey', {
+                    required: 'API Key is required',
+                  })}
+                  className="mt-1 block w-full rounded-md border border-gray-300 px-3 py-2 shadow-sm focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500"
+                />
+                {errors.apiKey && (
+                  <p className="mt-1 text-sm text-red-600">{errors.apiKey.message}</p>
+                )}
+              </div>
+
+              <button
+                type="submit"
+                disabled={connectMutation.isPending}
+                className="inline-flex justify-center py-2 px-4 border border-transparent rounded-md shadow-sm text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+              >
+                {connectMutation.isPending ? 'Connecting...' : 'Connect'}
+              </button>
+
+              <div className="rounded-md bg-blue-50 p-4">
+                <p className="text-sm text-blue-700">
+                  To find your Intervals.icu credentials:
+                </p>
+                <ol className="mt-2 text-sm text-blue-600 list-decimal list-inside space-y-1">
+                  <li>
+                    Go to <strong>intervals.icu</strong> and log in
+                  </li>
+                  <li>Click your profile icon in the top-right corner</li>
+                  <li>
+                    Select <strong>Settings</strong>
+                  </li>
+                  <li>
+                    Scroll down to <strong>Developer Settings</strong>
+                  </li>
+                  <li>
+                    Your <strong>Athlete ID</strong> is shown at the top of the page
+                    (starts with &quot;i&quot;)
+                  </li>
+                  <li>
+                    Click <strong>Show API Key</strong> to reveal your API key
+                  </li>
+                </ol>
+              </div>
+            </form>
+          )}
+        </div>
+      </div>
+    </AppLayout>
+  );
+}

--- a/apps/web/src/services/intervals-icu.service.ts
+++ b/apps/web/src/services/intervals-icu.service.ts
@@ -1,0 +1,37 @@
+import apiClient from '@/lib/api-client';
+
+export interface IntervalsIcuStatus {
+  connected: boolean;
+  athleteId?: string;
+  athleteName?: string;
+}
+
+interface ConnectIntervalsIcuDto {
+  athleteId: string;
+  apiKey: string;
+}
+
+interface ConnectIntervalsIcuResponse {
+  athleteName: string;
+}
+
+export const intervalsIcuService = {
+  async getConnectionStatus(): Promise<IntervalsIcuStatus> {
+    const response = await apiClient.get<IntervalsIcuStatus>(
+      '/users/me/intervals-icu/status',
+    );
+    return response.data;
+  },
+
+  async connect(data: ConnectIntervalsIcuDto): Promise<ConnectIntervalsIcuResponse> {
+    const response = await apiClient.put<ConnectIntervalsIcuResponse>(
+      '/users/me/intervals-icu',
+      data,
+    );
+    return response.data;
+  },
+
+  async disconnect(): Promise<void> {
+    await apiClient.delete('/users/me/intervals-icu');
+  },
+};

--- a/packages/shared-types/src/user/index.ts
+++ b/packages/shared-types/src/user/index.ts
@@ -1,2 +1,3 @@
 export * from './user.types';
 export * from './user-profile.types';
+export * from './intervals-icu.types';

--- a/packages/shared-types/src/user/intervals-icu.types.ts
+++ b/packages/shared-types/src/user/intervals-icu.types.ts
@@ -1,0 +1,14 @@
+export interface IntervalsIcuConnectionStatus {
+  connected: boolean;
+  athleteId?: string;
+  athleteName?: string;
+}
+
+export interface ConnectIntervalsIcuRequest {
+  athleteId: string;
+  apiKey: string;
+}
+
+export interface ConnectIntervalsIcuResponse {
+  athleteName: string;
+}


### PR DESCRIPTION
- Add Intervals.icu client to validate credentials against the API
- Add connect, disconnect, and status use cases following clean architecture
- Add Settings page with connection form and status display
- Extract shared RepositoryModule and AppLayout component
- Replace NestJS HTTP exceptions with domain exceptions + global filter
- Use HTTP 422 (not 401) for invalid Intervals.icu credentials to avoid triggering the frontend JWT interceptor logout